### PR TITLE
CI: Add Ubuntu 20.04, remove 16.04

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-16.04
         - ubuntu-18.04
+        - ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Ubuntu 16.04 environment was removed from GitHub in September.